### PR TITLE
Feat: game 페이지 기능 추가

### DIFF
--- a/src/components/board/index.tsx
+++ b/src/components/board/index.tsx
@@ -4,29 +4,34 @@ import { S } from "./style";
 type boardProps = {
   squares: Array<string>;
   handlePlay: (i: number) => void;
+  boardSize?: number;
 };
 
 export default function Board({
   squares,
   handlePlay,
+  boardSize,
 }: boardProps): JSX.Element {
+  const row = Array.from({ length: boardSize }, (_, index) => index);
+
   return (
     <>
-      <S.Row>
-        <Square value={squares[0]} handleClick={() => handlePlay(0)} />
-        <Square value={squares[1]} handleClick={() => handlePlay(1)} />
-        <Square value={squares[2]} handleClick={() => handlePlay(2)} />
-      </S.Row>
-      <S.Row>
-        <Square value={squares[3]} handleClick={() => handlePlay(3)} />
-        <Square value={squares[4]} handleClick={() => handlePlay(4)} />
-        <Square value={squares[5]} handleClick={() => handlePlay(5)} />
-      </S.Row>
-      <S.Row>
-        <Square value={squares[6]} handleClick={() => handlePlay(6)} />
-        <Square value={squares[7]} handleClick={() => handlePlay(7)} />
-        <Square value={squares[8]} handleClick={() => handlePlay(8)} />
-      </S.Row>
+      {row.map((ele, i) => {
+        return (
+          <S.Row key={ele}>
+            {row.map((ele, j) => {
+              const index = i * boardSize + j;
+              return (
+                <Square
+                  key={index}
+                  value={squares[index]}
+                  handleClick={() => handlePlay(index)}
+                />
+              );
+            })}
+          </S.Row>
+        );
+      })}
     </>
   );
 }

--- a/src/components/board/index.tsx
+++ b/src/components/board/index.tsx
@@ -1,25 +1,28 @@
 import Square from "../square";
 import { S } from "./style";
 
-type boardProps = {};
+type boardProps = {
+  squares: string | string[];
+  handlePlay: (i: number) => void;
+};
 
-export default function Board() {
+export default function Board({ squares, handlePlay }: boardProps) {
   return (
     <>
       <S.Row>
-        <Square value={0} />
-        <Square value={1} />
-        <Square value={2} />
+        <Square value={squares[0]} handleClick={() => handlePlay(0)} />
+        <Square value={squares[1]} handleClick={() => handlePlay(1)} />
+        <Square value={squares[2]} handleClick={() => handlePlay(2)} />
       </S.Row>
       <S.Row>
-        <Square value={3} />
-        <Square value={4} />
-        <Square value={5} />
+        <Square value={squares[3]} handleClick={() => handlePlay(3)} />
+        <Square value={squares[4]} handleClick={() => handlePlay(4)} />
+        <Square value={squares[5]} handleClick={() => handlePlay(5)} />
       </S.Row>
       <S.Row>
-        <Square value={6} />
-        <Square value={7} />
-        <Square value={8} />
+        <Square value={squares[6]} handleClick={() => handlePlay(6)} />
+        <Square value={squares[7]} handleClick={() => handlePlay(7)} />
+        <Square value={squares[8]} handleClick={() => handlePlay(8)} />
       </S.Row>
     </>
   );

--- a/src/components/board/index.tsx
+++ b/src/components/board/index.tsx
@@ -2,11 +2,14 @@ import Square from "../square";
 import { S } from "./style";
 
 type boardProps = {
-  squares: string | string[];
+  squares: Array<string>;
   handlePlay: (i: number) => void;
 };
 
-export default function Board({ squares, handlePlay }: boardProps) {
+export default function Board({
+  squares,
+  handlePlay,
+}: boardProps): JSX.Element {
   return (
     <>
       <S.Row>

--- a/src/components/common/button/index.tsx
+++ b/src/components/common/button/index.tsx
@@ -7,7 +7,12 @@ type buttonProps = {
   path?: string;
   startGame?: () => void;
 };
-export default function Button({ text, width, path, startGame }: buttonProps) {
+export default function Button({
+  text,
+  width,
+  path,
+  startGame,
+}: buttonProps): JSX.Element {
   const navigate = useNavigate();
 
   const moveToPage = (path: string) => {

--- a/src/components/common/button/index.tsx
+++ b/src/components/common/button/index.tsx
@@ -4,14 +4,16 @@ import { S } from "./style";
 type buttonProps = {
   text: string;
   width?: string;
-  path?: string;
+  path: string;
   startGame?: () => void;
+  saveGame?: () => void;
 };
 export default function Button({
   text,
   width,
   path,
   startGame,
+  saveGame,
 }: buttonProps): JSX.Element {
   const navigate = useNavigate();
 
@@ -20,11 +22,12 @@ export default function Button({
   };
 
   const onclick = () => {
-    if (path) {
-      moveToPage(path);
-    } else {
-      startGame && startGame();
+    if (startGame) {
+      startGame();
+    } else if (saveGame) {
+      saveGame();
     }
+    moveToPage(path);
   };
 
   return (

--- a/src/components/common/select/index.tsx
+++ b/src/components/common/select/index.tsx
@@ -14,7 +14,7 @@ export default function Select({
   value,
   handleInput,
   options,
-}: selectProps) {
+}: selectProps): JSX.Element {
   return (
     <S.Container>
       {title && <span>{title}</span>}

--- a/src/components/common/toggle/index.tsx
+++ b/src/components/common/toggle/index.tsx
@@ -3,11 +3,18 @@ import { S } from "./style";
 type toggleProps = {
   text: string;
   width?: string;
+  onclick?: () => void;
 };
-export default function Toggle({ text, width }: toggleProps) {
+export default function Toggle({
+  text,
+  width,
+  onclick,
+}: toggleProps): JSX.Element {
   return (
     <S.Container>
-      <S.Button $width={width}>{text}</S.Button>
+      <S.Button onClick={onclick} $width={width}>
+        {text}
+      </S.Button>
     </S.Container>
   );
 }

--- a/src/components/square/index.tsx
+++ b/src/components/square/index.tsx
@@ -1,7 +1,8 @@
 import { S } from "./style";
 type squareProps = {
   value: string | number;
+  handleClick: () => void;
 };
-export default function Square({ value }: squareProps) {
-  return <S.Square>{value}</S.Square>;
+export default function Square({ value, handleClick }: squareProps) {
+  return <S.Square onClick={handleClick}>{value}</S.Square>;
 }

--- a/src/components/square/index.tsx
+++ b/src/components/square/index.tsx
@@ -3,6 +3,9 @@ type squareProps = {
   value: string | number;
   handleClick: () => void;
 };
-export default function Square({ value, handleClick }: squareProps) {
+export default function Square({
+  value,
+  handleClick,
+}: squareProps): JSX.Element {
   return <S.Square onClick={handleClick}>{value}</S.Square>;
 }

--- a/src/components/square/index.tsx
+++ b/src/components/square/index.tsx
@@ -1,11 +1,26 @@
+import { useAtomValue } from "jotai";
+import { settingAtom } from "../../store/atom";
 import { S } from "./style";
 type squareProps = {
-  value: string | number;
+  value: string;
   handleClick: () => void;
 };
 export default function Square({
   value,
   handleClick,
 }: squareProps): JSX.Element {
-  return <S.Square onClick={handleClick}>{value}</S.Square>;
+  const setting = useAtomValue(settingAtom);
+
+  let color;
+  if (value === setting.player1Pattern) {
+    color = setting.player1Color;
+  } else if (value === setting.player2Pattern) {
+    color = setting.player2Color;
+  }
+
+  return (
+    <S.Square onClick={handleClick} $color={color}>
+      {value}
+    </S.Square>
+  );
 }

--- a/src/components/square/style.ts
+++ b/src/components/square/style.ts
@@ -1,7 +1,9 @@
 import { styled } from "styled-components";
 
 export const S = {
-  Square: styled.button`
+  Square: styled.button<{
+    $color?: string;
+  }>`
     background: #fff;
     border: 1px solid #999;
     float: left;
@@ -14,5 +16,6 @@ export const S = {
     text-align: center;
     width: 50px;
     height: 50px;
+    color: ${props => (props.$color ? props.$color : "#fff")};
   `,
 };

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -1,0 +1,1 @@
+export const a = 0;

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -1,1 +1,32 @@
-export const a = 0;
+export const boardSizeOption = [
+  "3 X 3",
+  "4 X 4",
+  "5 X 5",
+  "6 X 6",
+  "7 X 7",
+  "8 X 8",
+  "9 X 9",
+];
+
+export const colorOption = [
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "blue",
+  "navy",
+  "purple",
+  "pink",
+];
+export const shapeOption = ["X", "O", "♢", "♡", "♧", "♤", "▵", "◻︎"];
+
+export const startPlayerOption = ["random", "player1", "player2"];
+
+export const initValue = {
+  boardSize: "3 X 3",
+  player1Color: "blue",
+  player2Color: "red",
+  player1Pattern: "X",
+  player2Pattern: "O",
+  startPlayer: "random",
+};

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -25,8 +25,12 @@ export const startPlayerOption = ["random", "player1", "player2"];
 export const initValue = {
   boardSize: "3 X 3",
   player1Color: "blue",
-  player2Color: "red",
   player1Pattern: "X",
+  player2Color: "red",
   player2Pattern: "O",
   startPlayer: "random",
+};
+export const whoIsStartPlayer = {
+  first: "",
+  second: "",
 };

--- a/src/modules/fuction.ts
+++ b/src/modules/fuction.ts
@@ -1,0 +1,19 @@
+export const calculateWinner = squares => {
+  const lines = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+  ];
+  for (let i = 0; i < lines.length; i++) {
+    const [a, b, c] = lines[i];
+    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+      return squares[a];
+    }
+  }
+  return null;
+};

--- a/src/modules/fuction.ts
+++ b/src/modules/fuction.ts
@@ -53,3 +53,11 @@ export const chooseRandomPlayer = players => {
   const randomIndex = Math.floor(Math.random() * players.length);
   return players[randomIndex];
 };
+
+export const currentTime = new Date().toLocaleString("ko-KR", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});

--- a/src/modules/fuction.ts
+++ b/src/modules/fuction.ts
@@ -17,3 +17,8 @@ export const calculateWinner = (squares: Array<string>) => {
   }
   return null;
 };
+
+export const chooseRandomPlayer = players => {
+  const randomIndex = Math.floor(Math.random() * players.length);
+  return players[randomIndex];
+};

--- a/src/modules/fuction.ts
+++ b/src/modules/fuction.ts
@@ -1,4 +1,4 @@
-export const calculateWinner = squares => {
+export const calculateWinner = (squares: Array<string>) => {
   const lines = [
     [0, 1, 2],
     [3, 4, 5],

--- a/src/modules/fuction.ts
+++ b/src/modules/fuction.ts
@@ -1,18 +1,49 @@
-export const calculateWinner = (squares: Array<string>) => {
-  const lines = [
-    [0, 1, 2],
-    [3, 4, 5],
-    [6, 7, 8],
-    [0, 3, 6],
-    [1, 4, 7],
-    [2, 5, 8],
-    [0, 4, 8],
-    [2, 4, 6],
-  ];
+const calculateWinCondition = size => {
+  // 가로 라인
+  const lines = [];
+  for (let i = 0; i < size; i++) {
+    const line = [];
+    for (let j = 0; j < size; j++) {
+      line.push(i * size + j);
+    }
+    lines.push(line);
+  }
+  // 세로 라인
+  for (let i = 0; i < size; i++) {
+    const line = [];
+    for (let j = 0; j < size; j++) {
+      line.push(j * size + i);
+    }
+    lines.push(line);
+  }
+  // 대각선 라인
+  const diagonal1 = [];
+  const diagonal2 = [];
+  for (let i = 0; i < size; i++) {
+    diagonal1.push(i * size + i);
+    diagonal2.push(i * size + (size - 1 - i));
+  }
+  lines.push(diagonal1);
+  lines.push(diagonal2);
+
+  return lines;
+};
+
+export const calculateWinner = (squares: Array<string>, boardSize: number) => {
+  const lines = calculateWinCondition(boardSize);
   for (let i = 0; i < lines.length; i++) {
-    const [a, b, c] = lines[i];
-    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
-      return squares[a];
+    const line = lines[i];
+    const lineSize = line.length;
+    let winner = squares[line[0]];
+    let isWinner = true;
+    for (let j = 1; j < lineSize; j++) {
+      if (squares[line[j]] !== winner || !winner) {
+        isWinner = false;
+        break;
+      }
+    }
+    if (isWinner) {
+      return winner;
     }
   }
   return null;

--- a/src/pages/game/index.tsx
+++ b/src/pages/game/index.tsx
@@ -1,14 +1,16 @@
 import { useAtom } from "jotai";
 import Board from "../../components/board";
 import Button from "../../components/common/button";
-import Toggle from "../../components/common/toggle";
 import { S } from "./style";
 import { settingAtom } from "../../store/atom";
+import Player from "./player";
 
 export default function Game() {
   const [setting, setSetting] = useAtom(settingAtom);
 
   console.log(setting);
+  const cancelNum = 3;
+
   return (
     <S.Container>
       <S.Title>현재 마크 놓을 플레이어 : 1</S.Title>
@@ -18,45 +20,21 @@ export default function Game() {
         </div>
         <S.Settings>
           <S.Players>
-            <S.Player>
-              <S.PlayerName>player 1</S.PlayerName>
-              <S.Plate>
-                <div>
-                  <span>마크 모양 : </span>
-                  <span>O</span>
-                </div>
-                <div>
-                  <span>마크 색깔 : </span>
-                  <span>◼︎</span>
-                </div>
-                <div>
-                  <span>남은 무르기 : </span>
-                  <span> 3회</span>
-                </div>
-              </S.Plate>
-              <Toggle text="player1 무르기" width="122.5px" />
-            </S.Player>
-            <S.Player>
-              <S.PlayerName>player 2</S.PlayerName>
-              <S.Plate>
-                <div>
-                  <span> 마크 모양 : </span>
-                  <span>X</span>
-                </div>
-                <div>
-                  <span> 마크 색깔 : </span>
-                  <span>◼︎</span>
-                </div>
-                <div>
-                  <span> 남은 무르기 : </span>
-                  <span> 3회</span>
-                </div>
-              </S.Plate>
-              <Toggle text="player2 무르기" width="122.5px" />
-            </S.Player>
+            <Player
+              playerName="player 1"
+              color={setting.player1Color}
+              pattern={setting.player1Pattern}
+              number={cancelNum}
+            />
+            <Player
+              playerName="player 2"
+              color={setting.player2Color}
+              pattern={setting.player2Pattern}
+              number={cancelNum}
+            />
           </S.Players>
 
-          <Button text="게임 다시 시작하기" path="/" width="282px" />
+          <Button text="게임 다시 시작하기" path="/" width="299px" />
           {/* <Button text="게임 저장하기" path="/result" width="282px" /> */}
         </S.Settings>
       </S.BoardContainer>

--- a/src/pages/game/index.tsx
+++ b/src/pages/game/index.tsx
@@ -7,12 +7,19 @@ import Player from "./player";
 import { useState } from "react";
 import { calculateWinner } from "../../modules/fuction";
 
-export default function Game() {
+export default function Game(): JSX.Element {
   const setting = useAtomValue(settingAtom);
   const [history, setHistory] = useState([Array(9).fill("")]);
   const [currentMove, setCurrentMove] = useState(0);
   const currentSquares = history[currentMove];
   const xIsNext = currentMove % 2 === 0;
+  const [remainingTime, setRemainingTime] = useState({
+    player1: 3,
+    player2: 3,
+  });
+
+  console.log(currentSquares);
+  console.log(new Array(9));
 
   const handleHistory = nextSquares => {
     const nextHistory = [...history.slice(0, currentMove + 1), nextSquares];
@@ -32,7 +39,6 @@ export default function Game() {
     }
     handleHistory(nextSquares);
   };
-  const cancelNum = 3;
 
   const winner = calculateWinner(currentSquares);
   let status;
@@ -41,6 +47,19 @@ export default function Game() {
   } else {
     status = "현재 마크 놓을 플레이어 : " + (xIsNext ? "X" : "O");
   }
+  const minusMove = (player, time) => {
+    if (currentMove === 0) {
+      return alert("게임 시작 전입니다. 게임 시작 후 무르기를 해주세요.");
+    }
+    if (time === 0) {
+      return alert("무르기 횟수를 모두 사용하셨습니다.");
+    }
+    setCurrentMove(prev => prev - 1);
+    setRemainingTime(prevState => ({
+      ...prevState,
+      [player]: prevState[player] - 1,
+    }));
+  };
 
   return (
     <S.Container>
@@ -52,18 +71,21 @@ export default function Game() {
         <S.Settings>
           <S.Players>
             <Player
-              playerName="player 1"
+              playerName="player1"
               color={setting.player1Color}
               pattern={setting.player1Pattern}
-              number={cancelNum}
+              number={remainingTime.player1}
+              minusMove={minusMove}
             />
             <Player
-              playerName="player 2"
+              playerName="player2"
               color={setting.player2Color}
               pattern={setting.player2Pattern}
-              number={cancelNum}
+              number={remainingTime.player2}
+              minusMove={minusMove}
             />
           </S.Players>
+
           <Button text="게임 다시 시작하기" path="/" width="299px" />
           {/* <Button text="게임 저장하기" path="/result" width="282px" /> */}
         </S.Settings>

--- a/src/pages/game/index.tsx
+++ b/src/pages/game/index.tsx
@@ -19,7 +19,7 @@ export default function Game(): JSX.Element {
   });
 
   console.log(currentSquares);
-  console.log(new Array(9));
+  console.log(setting.startPlayer);
 
   const handleHistory = nextSquares => {
     const nextHistory = [...history.slice(0, currentMove + 1), nextSquares];
@@ -72,15 +72,11 @@ export default function Game(): JSX.Element {
           <S.Players>
             <Player
               playerName="player1"
-              color={setting.player1Color}
-              pattern={setting.player1Pattern}
               number={remainingTime.player1}
               minusMove={minusMove}
             />
             <Player
               playerName="player2"
-              color={setting.player2Color}
-              pattern={setting.player2Pattern}
               number={remainingTime.player2}
               minusMove={minusMove}
             />

--- a/src/pages/game/index.tsx
+++ b/src/pages/game/index.tsx
@@ -1,22 +1,53 @@
-import { useAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import Board from "../../components/board";
 import Button from "../../components/common/button";
 import { S } from "./style";
 import { settingAtom } from "../../store/atom";
 import Player from "./player";
+import { useState } from "react";
+import { calculateWinner } from "../../modules/fuction";
 
 export default function Game() {
-  const [setting, setSetting] = useAtom(settingAtom);
+  const setting = useAtomValue(settingAtom);
+  const [history, setHistory] = useState([Array(9).fill("")]);
+  const [currentMove, setCurrentMove] = useState(0);
+  const currentSquares = history[currentMove];
+  const xIsNext = currentMove % 2 === 0;
 
-  console.log(setting);
+  const handleHistory = nextSquares => {
+    const nextHistory = [...history.slice(0, currentMove + 1), nextSquares];
+    setHistory(nextHistory);
+    setCurrentMove(nextHistory.length - 1);
+  };
+
+  const handlePlay = (i: number) => {
+    if (currentSquares[i] || calculateWinner(currentSquares)) {
+      return;
+    }
+    const nextSquares = currentSquares.slice();
+    if (xIsNext) {
+      nextSquares[i] = "X";
+    } else {
+      nextSquares[i] = "O";
+    }
+    handleHistory(nextSquares);
+  };
   const cancelNum = 3;
+
+  const winner = calculateWinner(currentSquares);
+  let status;
+  if (winner) {
+    status = "Winner: " + winner;
+  } else {
+    status = "현재 마크 놓을 플레이어 : " + (xIsNext ? "X" : "O");
+  }
 
   return (
     <S.Container>
-      <S.Title>현재 마크 놓을 플레이어 : 1</S.Title>
+      <S.Title>{status}</S.Title>
       <S.BoardContainer>
         <div>
-          <Board />
+          <Board squares={currentSquares} handlePlay={handlePlay} />
         </div>
         <S.Settings>
           <S.Players>
@@ -33,7 +64,6 @@ export default function Game() {
               number={cancelNum}
             />
           </S.Players>
-
           <Button text="게임 다시 시작하기" path="/" width="299px" />
           {/* <Button text="게임 저장하기" path="/result" width="282px" /> */}
         </S.Settings>

--- a/src/pages/game/index.tsx
+++ b/src/pages/game/index.tsx
@@ -6,7 +6,7 @@ import Button from "../../components/common/button";
 import { playerOrderAtom, settingAtom } from "../../store/atom";
 import Player from "./player";
 import { useState } from "react";
-import { calculateWinner } from "../../modules/fuction";
+import { calculateWinner, currentTime } from "../../modules/fuction";
 
 export default function Game(): JSX.Element {
   const setting = useAtomValue(settingAtom);
@@ -75,6 +75,12 @@ export default function Game(): JSX.Element {
     }));
   };
 
+  const saveGame = () => {
+    const prev = JSON.parse(localStorage.getItem("history")) || [];
+    const newHistory = [...prev, { history: history, time: currentTime }];
+    localStorage.setItem("history", JSON.stringify(newHistory));
+  };
+
   return (
     <S.Container>
       <S.Title>{status}</S.Title>
@@ -100,7 +106,12 @@ export default function Game(): JSX.Element {
             />
           </S.Players>
           {isFinished ? (
-            <Button text="게임 저장하기" path="/result" width="282px" />
+            <Button
+              text="게임 저장하기"
+              saveGame={saveGame}
+              path="/result"
+              width="309px"
+            />
           ) : (
             <Button text="게임 다시 시작하기" path="/" width="309px" />
           )}

--- a/src/pages/game/index.tsx
+++ b/src/pages/game/index.tsx
@@ -10,8 +10,10 @@ import { calculateWinner } from "../../modules/fuction";
 
 export default function Game(): JSX.Element {
   const setting = useAtomValue(settingAtom);
+  const boardSize = Number(setting.boardSize.slice(0, 1));
+  const rowOfRows = boardSize * boardSize;
   const playerOrder = useAtomValue(playerOrderAtom);
-  const [history, setHistory] = useState([Array(9).fill("")]);
+  const [history, setHistory] = useState([Array(rowOfRows).fill("")]);
   const [currentMove, setCurrentMove] = useState(0);
   const currentSquares = history[currentMove];
   const xIsNext = currentMove % 2 === 0;
@@ -19,7 +21,7 @@ export default function Game(): JSX.Element {
     player1: 3,
     player2: 3,
   });
-  const winner = calculateWinner(currentSquares);
+  const winner = calculateWinner(currentSquares, boardSize);
   const isFull = currentSquares.filter(mark => mark === "").length === 0;
   const isFinished = !!winner || (isFull && currentMove > 0);
 
@@ -33,7 +35,7 @@ export default function Game(): JSX.Element {
   };
 
   const handlePlay = (i: number) => {
-    if (currentSquares[i] || calculateWinner(currentSquares)) {
+    if (currentSquares[i] || calculateWinner(currentSquares, boardSize)) {
       return;
     }
     const nextSquares = currentSquares.slice();
@@ -78,7 +80,11 @@ export default function Game(): JSX.Element {
       <S.Title>{status}</S.Title>
       <S.BoardContainer>
         <div>
-          <Board squares={currentSquares} handlePlay={handlePlay} />
+          <Board
+            squares={currentSquares}
+            handlePlay={handlePlay}
+            boardSize={boardSize}
+          />
         </div>
         <S.Settings>
           <S.Players>

--- a/src/pages/game/player/index.tsx
+++ b/src/pages/game/player/index.tsx
@@ -6,6 +6,7 @@ type playerProps = {
   color: string;
   pattern: string;
   number: number;
+  minusMove: (player: string, time: number) => void;
 };
 
 export default function Player({
@@ -13,7 +14,8 @@ export default function Player({
   color,
   pattern,
   number,
-}: playerProps) {
+  minusMove,
+}: playerProps): JSX.Element {
   const plateOption = [
     { text: "마크 모양 : ", id: 1, mark: pattern },
     { text: "마크 색깔 : ", id: 2, mark: color },
@@ -33,7 +35,11 @@ export default function Player({
           );
         })}
       </S.Plate>
-      <Toggle text={`${playerName} 무르기`} width="130px" />
+      <Toggle
+        text={`${playerName} 무르기`}
+        width="130px"
+        onclick={() => minusMove(playerName, number)}
+      />
     </S.Container>
   );
 }

--- a/src/pages/game/player/index.tsx
+++ b/src/pages/game/player/index.tsx
@@ -42,7 +42,7 @@ export default function Player({
       </S.Plate>
       <Toggle
         text={`${playerName} 무르기`}
-        width="130px"
+        width="135px"
         onclick={() => minusMove(playerName, number)}
       />
     </S.Container>

--- a/src/pages/game/player/index.tsx
+++ b/src/pages/game/player/index.tsx
@@ -1,24 +1,23 @@
+import { useAtomValue } from "jotai";
 import Toggle from "../../../components/common/toggle";
 import { S } from "./style";
+import { settingAtom } from "../../../store/atom";
 
 type playerProps = {
   playerName: string;
-  color: string;
-  pattern: string;
   number: number;
   minusMove: (player: string, time: number) => void;
 };
 
 export default function Player({
   playerName,
-  color,
-  pattern,
   number,
   minusMove,
 }: playerProps): JSX.Element {
+  const setting = useAtomValue(settingAtom);
   const plateOption = [
-    { text: "마크 모양 : ", id: 1, mark: pattern },
-    { text: "마크 색깔 : ", id: 2, mark: color },
+    { text: "마크 모양 : ", id: 1, mark: setting[`${playerName}Pattern`] },
+    { text: "마크 색깔 : ", id: 2, mark: setting[`${playerName}Color`] },
     { text: "남은 무르기 : ", id: 3, mark: `${number}회` },
   ];
 
@@ -30,7 +29,13 @@ export default function Player({
           return (
             <div key={option.id}>
               <span>{option.text}</span>
-              <span>{option.mark}</span>
+              {option.id === 3 ? (
+                <span>{option.mark}</span>
+              ) : (
+                <S.MarkColor $color={setting[`${playerName}Color`]}>
+                  {option.mark}
+                </S.MarkColor>
+              )}
             </div>
           );
         })}

--- a/src/pages/game/player/index.tsx
+++ b/src/pages/game/player/index.tsx
@@ -1,0 +1,39 @@
+import Toggle from "../../../components/common/toggle";
+import { S } from "./style";
+
+type playerProps = {
+  playerName: string;
+  color: string;
+  pattern: string;
+  number: number;
+};
+
+export default function Player({
+  playerName,
+  color,
+  pattern,
+  number,
+}: playerProps) {
+  const plateOption = [
+    { text: "마크 모양 : ", id: 1, mark: pattern },
+    { text: "마크 색깔 : ", id: 2, mark: color },
+    { text: "남은 무르기 : ", id: 3, mark: `${number}회` },
+  ];
+
+  return (
+    <S.Container>
+      <S.PlayerName>{playerName}</S.PlayerName>
+      <S.Plate>
+        {plateOption.map(option => {
+          return (
+            <div key={option.id}>
+              <span>{option.text}</span>
+              <span>{option.mark}</span>
+            </div>
+          );
+        })}
+      </S.Plate>
+      <Toggle text={`${playerName} 무르기`} width="130px" />
+    </S.Container>
+  );
+}

--- a/src/pages/game/player/style.ts
+++ b/src/pages/game/player/style.ts
@@ -21,4 +21,10 @@ export const S = {
     gap: 5px;
     width: 130px;
   `,
+
+  MarkColor: styled.span<{
+    $color?: string;
+  }>`
+    color: ${props => (props.$color ? props.$color : "#ggg")};
+  `,
 };

--- a/src/pages/game/player/style.ts
+++ b/src/pages/game/player/style.ts
@@ -19,12 +19,12 @@ export const S = {
     display: flex;
     flex-direction: column;
     gap: 5px;
-    width: 130px;
+    width: 135px;
   `,
 
   MarkColor: styled.span<{
     $color?: string;
   }>`
-    color: ${props => (props.$color ? props.$color : "#ggg")};
+    color: ${props => (props.$color ? props.$color : "#fff")};
   `,
 };

--- a/src/pages/game/player/style.ts
+++ b/src/pages/game/player/style.ts
@@ -1,0 +1,24 @@
+import { styled } from "styled-components";
+
+export const S = {
+  Container: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  `,
+
+  PlayerName: styled.span`
+    font-size: 20px;
+  `,
+
+  Plate: styled.div`
+    background-color: #ffaa4066;
+    border-radius: 5px;
+    padding: 7px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    width: 130px;
+  `,
+};

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,7 +1,7 @@
 import { S } from "./style";
 import Button from "../../components/common/button";
 
-export default function Main() {
+export default function Main(): JSX.Element {
   return (
     <S.Container>
       <S.Title>Tic Tac Toe</S.Title>

--- a/src/pages/readiness/index.tsx
+++ b/src/pages/readiness/index.tsx
@@ -7,7 +7,7 @@ import { settingAtom } from "../../store/atom";
 import { useNavigate } from "react-router";
 import Select from "../../components/common/select";
 
-export default function Readiness() {
+export default function Readiness(): JSX.Element {
   const { inputValue, handleInput } = useInputValue(initValue);
   const setSetting = useSetAtom(settingAtom);
   const navigate = useNavigate();

--- a/src/pages/readiness/index.tsx
+++ b/src/pages/readiness/index.tsx
@@ -3,7 +3,7 @@ import { S } from "./style";
 import Button from "../../components/common/button";
 import useInputValue from "../../hooks/useInputValue";
 import { useSetAtom } from "jotai";
-import { settingAtom } from "../../store/atom";
+import { playerOrderAtom, settingAtom } from "../../store/atom";
 import { useNavigate } from "react-router";
 import Select from "../../components/common/select";
 import {
@@ -18,16 +18,24 @@ import { chooseRandomPlayer } from "../../modules/fuction";
 export default function Readiness(): JSX.Element {
   const { inputValue, handleInput } = useInputValue(initValue);
   const setSetting = useSetAtom(settingAtom);
+  const setOrder = useSetAtom(playerOrderAtom);
   const navigate = useNavigate();
   const winScore = inputValue.boardSize.slice(0, 1);
 
   const startGame = (path: string) => {
+    const playerArr = startPlayerOption.slice(1, 3);
     if (inputValue.startPlayer === "random") {
-      const isFirstPlayer = chooseRandomPlayer(startPlayerOption.slice(1, 3));
-      setSetting({ ...inputValue, startPlayer: isFirstPlayer });
+      const isFirstPlayer = chooseRandomPlayer(playerArr);
+      const secondPlayer = playerArr.filter(player => player !== isFirstPlayer);
+      setSetting(inputValue);
+      setOrder({ first: isFirstPlayer, second: secondPlayer[0] });
       navigate(path);
     } else {
+      const secondPlayer = playerArr.filter(
+        player => player !== inputValue.startPlayer,
+      );
       setSetting(inputValue);
+      setOrder({ first: inputValue.startPlayer, second: secondPlayer[0] });
       navigate(path);
     }
   };

--- a/src/pages/readiness/index.tsx
+++ b/src/pages/readiness/index.tsx
@@ -6,6 +6,14 @@ import { useSetAtom } from "jotai";
 import { settingAtom } from "../../store/atom";
 import { useNavigate } from "react-router";
 import Select from "../../components/common/select";
+import {
+  boardSizeOption,
+  colorOption,
+  initValue,
+  shapeOption,
+  startPlayerOption,
+} from "../../modules/constants";
+import { chooseRandomPlayer } from "../../modules/fuction";
 
 export default function Readiness(): JSX.Element {
   const { inputValue, handleInput } = useInputValue(initValue);
@@ -14,8 +22,14 @@ export default function Readiness(): JSX.Element {
   const winScore = inputValue.boardSize.slice(0, 1);
 
   const startGame = (path: string) => {
-    setSetting(inputValue);
-    navigate(path);
+    if (inputValue.startPlayer === "random") {
+      const isFirstPlayer = chooseRandomPlayer(startPlayerOption.slice(1, 3));
+      setSetting({ ...inputValue, startPlayer: isFirstPlayer });
+      navigate(path);
+    } else {
+      setSetting(inputValue);
+      navigate(path);
+    }
   };
 
   return (
@@ -91,36 +105,3 @@ export default function Readiness(): JSX.Element {
     </S.Container>
   );
 }
-
-const initValue = {
-  boardSize: "3 X 3",
-  player1Color: "파랑색",
-  player2Color: "빨강색",
-  player1Pattern: "X",
-  player2Pattern: "O",
-  startPlayer: "random",
-};
-
-const boardSizeOption = [
-  "3 X 3",
-  "4 X 4",
-  "5 X 5",
-  "6 X 6",
-  "7 X 7",
-  "8 X 8",
-  "9 X 9",
-];
-
-const colorOption = [
-  "빨강색",
-  "주황색",
-  "노랑색",
-  "초록색",
-  "파랑색",
-  "남색",
-  "보라색",
-  "핑크색",
-];
-const shapeOption = ["X", "O", "♢", "♡", "♧", "♤", "▵", "◻︎"];
-
-const startPlayerOption = ["랜덤", "플레이어1", "플레이어2"];

--- a/src/pages/readiness/index.tsx
+++ b/src/pages/readiness/index.tsx
@@ -19,24 +19,21 @@ export default function Readiness(): JSX.Element {
   const { inputValue, handleInput } = useInputValue(initValue);
   const setSetting = useSetAtom(settingAtom);
   const setOrder = useSetAtom(playerOrderAtom);
-  const navigate = useNavigate();
   const winScore = inputValue.boardSize.slice(0, 1);
 
-  const startGame = (path: string) => {
+  const startGame = () => {
     const playerArr = startPlayerOption.slice(1, 3);
     if (inputValue.startPlayer === "random") {
       const isFirstPlayer = chooseRandomPlayer(playerArr);
       const secondPlayer = playerArr.filter(player => player !== isFirstPlayer);
       setSetting(inputValue);
       setOrder({ first: isFirstPlayer, second: secondPlayer[0] });
-      navigate(path);
     } else {
       const secondPlayer = playerArr.filter(
         player => player !== inputValue.startPlayer,
       );
       setSetting(inputValue);
       setOrder({ first: inputValue.startPlayer, second: secondPlayer[0] });
-      navigate(path);
     }
   };
 
@@ -109,7 +106,7 @@ export default function Readiness(): JSX.Element {
           </S.Caution>
         </S.Space>
       </S.SettingContainer>
-      <Button text="게임 시작" startGame={() => startGame("/game")} />
+      <Button text="게임 시작" startGame={startGame} path="/game" />
     </S.Container>
   );
 }

--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -3,7 +3,7 @@ import Button from "../../components/common/button";
 import Toggle from "../../components/common/toggle";
 import { S } from "./style";
 
-export default function Result() {
+export default function Result(): JSX.Element {
   return (
     <S.Container>
       <S.Title>게임 결과</S.Title>

--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -9,7 +9,7 @@ export default function Result() {
       <S.Title>게임 결과</S.Title>
       <S.BoardContainer>
         <Toggle text="2023년2월16일 00시00분" />
-        <Board />
+        <Board squares={[]} handlePlay={null} />
       </S.BoardContainer>
       <Button text="게임 다시 시작하기" path="/" />
     </S.Container>

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -1,11 +1,5 @@
 import { atom } from "jotai";
 import { inputValueData } from "../types/type";
+import { initValue } from "../modules/constants";
 
-export const settingAtom = atom<inputValueData>({
-  boardSize: "3 X 3",
-  player1Color: "파랑색",
-  player2Color: "빨강색",
-  player1Pattern: "X",
-  player2Pattern: "O",
-  startPlayer: "random",
-});
+export const settingAtom = atom<inputValueData>(initValue);

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -1,5 +1,7 @@
 import { atom } from "jotai";
 import { inputValueData } from "../types/type";
-import { initValue } from "../modules/constants";
+import { initValue, whoIsStartPlayer } from "../modules/constants";
 
 export const settingAtom = atom<inputValueData>(initValue);
+
+export const playerOrderAtom = atom<inputValueData>(whoIsStartPlayer);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,12 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
+    "strict": false,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## 1. 해당 브랜치에서 작업한 내용
- board 컴포넌트 내에서 map으로 코드 양 줄임
- toggle, player 컴포넌트 분리
- 유저가 시작 플레이어를 랜덤으로 설정했을 시 Math.random 이용해 무작위로 플레이어 추출 후 적용
- 유저가 설정한 모양과 색깔을 마크에 적용
- 유저가 설정한 게임판의 크기 적용
- 게임판의 크기에 따라 이기는 플레이어 계산하는 로직 추가
- 게임이 종료되면 로컬 스토리지에 게임결과와 관련된 데이터 저장 후 결과 페이지로 이등

## 2. 작업한 결과물
![tictactoe_game](https://github.com/hjyang369/proj.TicTacToe/assets/125977702/ad0b727e-ee3b-46d3-82d4-6d515588550d)


## 3. 해당 작업을 하면서 생겼던 이슈사항
- 먼저 3x3 기본을 먼저 구현을 하고 이후 nxn이 적용될 수 있도록 구현하였습니다. 알고리즘처럼 적용해야하는 부분이 조금 까다롭게 느껴졌습니다.

## 4. 해당 작업을 통해 알게 된 내용
- 알고리즘