### PR TITLE
Feat: 결과 페이지 기능 추가

### DIFF
--- a/src/hooks/useInputValue.ts
+++ b/src/hooks/useInputValue.ts
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { inputValueData } from "../types/type";
+import { TStringObj } from "../types/type";
 
-const useInputValue = (initInput: inputValueData) => {
-  const [inputValue, setInputValue] = useState<inputValueData>(initInput);
+const useInputValue = (initInput: TStringObj) => {
+  const [inputValue, setInputValue] = useState<TStringObj>(initInput);
 
   const handleInput = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     const { name, value } = e.target;

--- a/src/pages/game/index.tsx
+++ b/src/pages/game/index.tsx
@@ -24,6 +24,7 @@ export default function Game(): JSX.Element {
   const winner = calculateWinner(currentSquares, boardSize);
   const isFull = currentSquares.filter(mark => mark === "").length === 0;
   const isFinished = !!winner || (isFull && currentMove > 0);
+  const [moveNum, setMoveNum] = useState(Array(rowOfRows).fill(undefined));
 
   const handleHistory = nextSquares => {
     const nextHistory = [...history.slice(0, currentMove + 1), nextSquares];
@@ -36,12 +37,15 @@ export default function Game(): JSX.Element {
       return;
     }
     const nextSquares = currentSquares.slice();
+    const moveSquares = moveNum.slice();
     if (xIsNext) {
       nextSquares[i] = setting[`${playerOrder.first}Pattern`];
     } else {
       nextSquares[i] = setting[`${playerOrder.second}Pattern`];
     }
+    moveSquares[i] = currentMove + 1;
     handleHistory(nextSquares);
+    setMoveNum(moveSquares);
   };
 
   let status;
@@ -81,6 +85,9 @@ export default function Game(): JSX.Element {
         history: history,
         time: currentTime,
         boardSize: boardSize,
+        moveNum: moveNum,
+        setting: setting,
+        winner: status,
       },
     ];
     localStorage.setItem("history", JSON.stringify(newHistory));

--- a/src/pages/game/index.tsx
+++ b/src/pages/game/index.tsx
@@ -25,9 +25,6 @@ export default function Game(): JSX.Element {
   const isFull = currentSquares.filter(mark => mark === "").length === 0;
   const isFinished = !!winner || (isFull && currentMove > 0);
 
-  console.log(">>", isFinished);
-  console.log(currentSquares);
-
   const handleHistory = nextSquares => {
     const nextHistory = [...history.slice(0, currentMove + 1), nextSquares];
     setHistory(nextHistory);
@@ -77,7 +74,15 @@ export default function Game(): JSX.Element {
 
   const saveGame = () => {
     const prev = JSON.parse(localStorage.getItem("history")) || [];
-    const newHistory = [...prev, { history: history, time: currentTime }];
+    const newHistory = [
+      ...prev,
+      {
+        id: new Date(),
+        history: history,
+        time: currentTime,
+        boardSize: boardSize,
+      },
+    ];
     localStorage.setItem("history", JSON.stringify(newHistory));
   };
 

--- a/src/pages/result/board/index.tsx
+++ b/src/pages/result/board/index.tsx
@@ -1,0 +1,42 @@
+import { TStringObj } from "../../../types/type";
+import Square from "../square/index";
+import { S } from "./style";
+
+type boardProps = {
+  squares: Array<string>;
+  boardSize?: number;
+  setting: TStringObj;
+  moveNum: Array<number>;
+};
+
+export default function Board({
+  squares,
+  boardSize,
+  setting,
+  moveNum,
+}: boardProps): JSX.Element {
+  const row = Array.from({ length: boardSize }, (_, index) => index);
+  const result = squares[squares.length - 1];
+
+  return (
+    <>
+      {row.map((ele, i) => {
+        return (
+          <S.Row key={ele}>
+            {row.map((ele, j) => {
+              const index = i * boardSize + j;
+              return (
+                <Square
+                  key={index}
+                  value={result[index]}
+                  setting={setting}
+                  moveNum={moveNum[index]}
+                />
+              );
+            })}
+          </S.Row>
+        );
+      })}
+    </>
+  );
+}

--- a/src/pages/result/board/style.ts
+++ b/src/pages/result/board/style.ts
@@ -1,0 +1,11 @@
+import { styled } from "styled-components";
+
+export const S = {
+  Row: styled.div`
+    &::after {
+      clear: both;
+      content: "";
+      display: table;
+    }
+  `,
+};

--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import Board from "../../components/board";
+import Board from "./board/index";
 import Button from "../../components/common/button";
 import Toggle from "../../components/common/toggle";
 import { S } from "./style";
@@ -8,7 +8,6 @@ import { TBooleanObj } from "../../types/type";
 export default function Result(): JSX.Element {
   const [toggle, setToggle] = useState<TBooleanObj>({});
   const history = JSON.parse(localStorage.getItem("history")) || [];
-
   const handleToggle = (id: string) => {
     setToggle(prev => ({ ...prev, [id]: !prev[id] }));
   };
@@ -16,24 +15,29 @@ export default function Result(): JSX.Element {
   return (
     <S.Container>
       <S.Title>게임 결과</S.Title>
-      {history.map(content => {
-        return (
-          <S.BoardContainer key={content.id}>
-            <Toggle
-              text={content.time}
-              onclick={() => handleToggle(content.id)}
-            />
-            {toggle[content.id] && (
-              <Board
-                squares={content.history}
-                handlePlay={null}
-                boardSize={content.boardSize}
+      <S.Result>
+        {history.map(content => {
+          return (
+            <S.BoardContainer key={content.id}>
+              <Toggle
+                text={content.time}
+                onclick={() => handleToggle(content.id)}
               />
-            )}
-          </S.BoardContainer>
-        );
-      })}
-
+              {toggle[content.id] && (
+                <div>
+                  <S.Winner>{content.winner}</S.Winner>
+                  <Board
+                    squares={content.history}
+                    boardSize={content.boardSize}
+                    setting={content.setting}
+                    moveNum={content.moveNum}
+                  />
+                </div>
+              )}
+            </S.BoardContainer>
+          );
+        })}
+      </S.Result>
       <Button text="게임 다시 시작하기" path="/" />
     </S.Container>
   );

--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -1,16 +1,39 @@
+import { useState } from "react";
 import Board from "../../components/board";
 import Button from "../../components/common/button";
 import Toggle from "../../components/common/toggle";
 import { S } from "./style";
+import { TBooleanObj } from "../../types/type";
 
 export default function Result(): JSX.Element {
+  const [toggle, setToggle] = useState<TBooleanObj>({});
+  const history = JSON.parse(localStorage.getItem("history")) || [];
+
+  const handleToggle = (id: string) => {
+    setToggle(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
   return (
     <S.Container>
       <S.Title>게임 결과</S.Title>
-      <S.BoardContainer>
-        <Toggle text="2023년2월16일 00시00분" />
-        <Board squares={[]} handlePlay={null} />
-      </S.BoardContainer>
+      {history.map(content => {
+        return (
+          <S.BoardContainer key={content.id}>
+            <Toggle
+              text={content.time}
+              onclick={() => handleToggle(content.id)}
+            />
+            {toggle[content.id] && (
+              <Board
+                squares={content.history}
+                handlePlay={null}
+                boardSize={content.boardSize}
+              />
+            )}
+          </S.BoardContainer>
+        );
+      })}
+
       <Button text="게임 다시 시작하기" path="/" />
     </S.Container>
   );

--- a/src/pages/result/square/index.tsx
+++ b/src/pages/result/square/index.tsx
@@ -1,0 +1,27 @@
+import { TStringObj } from "../../../types/type";
+import { S } from "./style";
+
+type squareProps = {
+  value: string;
+  setting: TStringObj;
+  moveNum: number;
+};
+export default function Square({
+  value,
+  setting,
+  moveNum,
+}: squareProps): JSX.Element {
+  let color;
+  if (value === setting.player1Pattern) {
+    color = setting.player1Color;
+  } else if (value === setting.player2Pattern) {
+    color = setting.player2Color;
+  }
+
+  return (
+    <S.Square $color={color}>
+      {value}
+      <br />({moveNum}번째)
+    </S.Square>
+  );
+}

--- a/src/pages/result/square/style.ts
+++ b/src/pages/result/square/style.ts
@@ -1,0 +1,20 @@
+import { styled } from "styled-components";
+
+export const S = {
+  Square: styled.div<{
+    $color?: string;
+  }>`
+    background: #fff;
+    border: 1px solid #999;
+    float: left;
+    font-size: 15px;
+    font-weight: bold;
+    line-height: 34px;
+    margin-right: -1px;
+    margin-top: -1px;
+    text-align: center;
+    width: 65px;
+    height: 65px;
+    color: ${props => (props.$color ? props.$color : "#fff")};
+  `,
+};

--- a/src/pages/result/style.ts
+++ b/src/pages/result/style.ts
@@ -6,6 +6,7 @@ export const S = {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    gap: 15px;
   `,
   Title: styled.h1`
     font-weight: 700;
@@ -18,5 +19,21 @@ export const S = {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+  `,
+
+  Result: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 15px;
+  `,
+
+  Winner: styled.span`
+    display: block;
+    font-size: 15px;
+    text-align: center;
+    font-weight: 700;
+    margin: 10px 0;
   `,
 };

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -1,7 +1,7 @@
 import { atom } from "jotai";
-import { inputValueData } from "../types/type";
+import { TStringObj } from "../types/type";
 import { initValue, whoIsStartPlayer } from "../modules/constants";
 
-export const settingAtom = atom<inputValueData>(initValue);
+export const settingAtom = atom<TStringObj>(initValue);
 
-export const playerOrderAtom = atom<inputValueData>(whoIsStartPlayer);
+export const playerOrderAtom = atom<TStringObj>(whoIsStartPlayer);

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,3 +1,7 @@
-export interface inputValueData {
+export type TStringObj = {
   [key: string]: string;
-}
+};
+
+export type TBooleanObj = {
+  [key: string]: boolean;
+};


### PR DESCRIPTION
## 1. 해당 브랜치에서 작업한 내용
- 날짜 버튼 클릭 시 토글 오픈
- 로컬스토리지에 저장된 결과 보여주기 
- 유저가 마크 놓을때 순서도 같이 저장하도록 변경

## 2. 작업한 결과물
![tictactoe_result](https://github.com/hjyang369/proj.TicTacToe/assets/125977702/03fb4662-973d-4ca5-944f-56ebc9bc67f9)


## 3. 해당 작업을 하면서 생겼던 이슈사항
- 전체 마크에 대한 히스토리가 저장된 배열로 마크 순서를 나타내려고 했는데 로직이 많이 복잡함을 느꼈습니다. 그래서 유저가 마크를 놓을 때 같이 순서도 저장할 수 있도록 변경하였습니다. 그리고 저장된 순서를 마크와 함께 보여주었습니다.

## 4. 해당 작업을 통해 알게 된 내용
- 없음